### PR TITLE
Remove topic overlap between the database and application topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,19 @@ Piggy Bank is a secrets storage tool for applications that works with NATS. Secr
 
 A decryption key is returned from the initialization phase. If this key is lost, all of the data is unrecoverable.
 
+## Add KV bucket
+
+Be sure to add the KV bucket to NATS: `nats kv add piggybank`
+
 ## Example Usage
 
 1. Start piggybank `piggybank start`
-2. Initialize the database `nats req piggybank.database.initialize ""`
-3. Unlock the database with key sent from step 1 `nats req piggybank.database.unlock '{"database_key": "foobar"}'`
+2. Initialize the database `nats req piggybankdb.initialize ""`
+3. Unlock the database with key sent from step 1 `nats req piggybankdb.unlock '{"database_key": "foobar"}'`
 4. Add a secret for an application `nats req -H method:post piggybank.myapplication.registrySecret "somesecrettext"`
-5. Retrieve a secret `nats req -H method:get piggybank.myapplication.registrySecret`
-6. Lock the database `nats req piggybank.database.lock ""`
-7. Try to retrieve the secret again `nats req -H method:get piggybank.myapplication.registrySecret`
+5. Retrieve a secret `nats req -H method:get piggybank.myapplication.registrySecret ""`
+6. Lock the database `nats req piggybankdb.lock ""`
+7. Try to retrieve the secret again `nats req -H method:get piggybank.myapplication.registrySecret ""`
 
 ## Permissions
 Permissions are defined as normal NATS subject permissions. If you have access to a subject, then you can retrieve the secrets. This means the permissions can be as granular as desired.

--- a/server/nats.go
+++ b/server/nats.go
@@ -70,7 +70,7 @@ func (n *NatsBackend) SetupMicro() error {
 		return err
 	}
 
-	databaseGroup := srv.AddGroup("piggybank.database")
+	databaseGroup := srv.AddGroup("piggybankdb")
 	if err := databaseGroup.AddEndpoint("lock", micro.HandlerFunc(n.LockRequest)); err != nil {
 		return err
 	}


### PR DESCRIPTION
Having both the database (`piggybank.database.XXX`) and application (`piggybank.>`) topics overlap subscription hierarchies causes random issues when trying to run `nats req piggybank.database.XXX` requests. Sometimes the requests are handled by the micro service's endpoint handler and sometimes they are handled by the group handlers for the database. See below:

```
❯ nats req piggybank.database.initialize ""
19:57:42 Sending request on "piggybank.database.initialize"
19:57:42 Received with rtt 2.283735ms
19:57:42 Status: 403

{"error":"database locked","Code":403}



piggybank on  main [📝] via 🐹 v1.22.1 
❯ nats req piggybank.database.initialize ""
19:57:53 Sending request on "piggybank.database.initialize"
19:57:53 Received with rtt 1.507074ms
19:57:53 Status: 403

{"error":"database locked","Code":403}



piggybank on  main [📝] via 🐹 v1.22.1 
❯ nats req piggybank.database.initialize ""
19:57:55 Sending request on "piggybank.database.initialize"
19:57:55 Received with rtt 5.134594ms
19:57:55 Status: 200

{"details":"iHDys5Y+ZwRAr7szyy527jiESx9HH93ToCAX11JthPU","Code":200}



piggybank on  main [📝] via 🐹 v1.22.1 
❯ nats req piggybank.database.unlock '{"database_key": "iHDys5Y+ZwRAr7szyy527jiESx9HH93ToCAX11JthPU"}'
19:59:00 Sending request on "piggybank.database.unlock"
19:59:00 Received with rtt 2.322842ms
19:59:00 Status: 403

{"error":"database locked","Code":403}



piggybank on  main [📝] via 🐹 v1.22.1 
❯ nats req piggybank.database.unlock '{"database_key": "iHDys5Y+ZwRAr7szyy527jiESx9HH93ToCAX11JthPU"}'
19:59:07 Sending request on "piggybank.database.unlock"
19:59:07 Received with rtt 1.399512ms
19:59:07 Status: 403

{"error":"database locked","Code":403}



piggybank on  main [📝] via 🐹 v1.22.1 
❯ nats req piggybank.database.unlock '{"database_key": "iHDys5Y+ZwRAr7szyy527jiESx9HH93ToCAX11JthPU"}'
19:59:09 Sending request on "piggybank.database.unlock"
19:59:09 Received with rtt 8.302866ms
19:59:09 Status: 200

{"details":"database successfully unlocked","Code":200}

```

I ran this test using both NATS 2.10.10 and 2.10.11 on both Debian 12 and openSUSE Tumbleweed and it behaves the same way across both distros and NATS versions.

If we keep the database and application topic subscriptions from overlapping, it solves the randomness issues.

```
piggybank on  main [📝] via 🐹 v1.22.1 
❯ nats req piggybankdb.unlock '{"database_key": "iHDys5Y+ZwRAr7szyy527jiESx9HH93ToCAX11JthPU"}'
20:37:17 Sending request on "piggybankdb.unlock"
20:37:17 Received with rtt 9.490961ms
20:37:17 Status: 200

{"details":"database successfully unlocked","Code":200}



piggybank on  main [📝] via 🐹 v1.22.1 
❯ nats req piggybankdb.lock ""
20:37:21 Sending request on "piggybankdb.lock"
20:37:21 Received with rtt 1.382836ms
20:37:21 Status: 200

{"details":"database locked","Code":200}



piggybank on  main [📝] via 🐹 v1.22.1 
❯ nats req piggybankdb.unlock '{"database_key": "iHDys5Y+ZwRAr7szyy527jiESx9HH93ToCAX11JthPU"}'
20:37:24 Sending request on "piggybankdb.unlock"
20:37:24 Received with rtt 5.166875ms
20:37:24 Status: 200

{"details":"database successfully unlocked","Code":200}



piggybank on  main [📝] via 🐹 v1.22.1 
❯ nats req piggybankdb.lock ""
20:37:25 Sending request on "piggybankdb.lock"
20:37:25 Received with rtt 1.379243ms
20:37:25 Status: 200

{"details":"database locked","Code":200}
```

Not sure if this is how you would want to solve this issue or not but I thought I would throw it out there for discussion.
